### PR TITLE
fix(enchantments): Fix merge level not picking highest

### DIFF
--- a/src/main/java/de/bydora/tesserTools/enchantment/listeners/PlayerDropItemListener.java
+++ b/src/main/java/de/bydora/tesserTools/enchantment/listeners/PlayerDropItemListener.java
@@ -373,11 +373,12 @@ public class PlayerDropItemListener implements Listener {
                 usedLevel += 3;
                 vanillas.put(ench, mergeLevel + 1);
             }
-            // If not just use the one from the first map
+            // If not just use the higher one
             else if (ench.getMaxLevel() >= item1Level
+                    && ench.getMaxLevel() >= mergeLevel
             ) {
                 usedLevel += 3;
-                vanillas.put(ench, item1Level);
+                vanillas.put(ench, Math.max(mergeLevel, item1Level));
             }
 
 


### PR DESCRIPTION
This PR fixes an issue where merging books would not give you the higher level if you threw it in the "wrong" order. 