### PR TITLE
ref: Needed blocks for area enchantments

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'de.bydora'
-version = '1.8.0'
+version = '1.8.1'
 
 repositories {
     mavenCentral()

--- a/src/main/java/de/bydora/tesserTools/enchantment/enchantments/AreaFill.java
+++ b/src/main/java/de/bydora/tesserTools/enchantment/enchantments/AreaFill.java
@@ -49,8 +49,7 @@ public class AreaFill extends CustomEnchantment<PlayerInteractEvent> {
         final int level = getEnchantmentLevel(event.getItem());
         final var player = event.getPlayer();
         var airBlocks = getAirBlocks(event.getClickedBlock(), player.getFacing(), level > 1 ? 5 : 3);
-        var availableItems = getAvailableItems(player.getInventory(), fillBlocks,
-                level > 1 ? 25 : 9);
+        var availableItems = getAvailableItems(player.getInventory(), fillBlocks, airBlocks.size());
         if (Objects.isNull(availableItems)) {
             ResourceBundle l18 = ResourceBundle.getBundle("translations.tools", player.locale());
             player.sendMessage(l18.getString("areaEnchNotEnoughItems"));

--- a/src/main/java/de/bydora/tesserTools/enchantment/enchantments/SpaceFill.java
+++ b/src/main/java/de/bydora/tesserTools/enchantment/enchantments/SpaceFill.java
@@ -75,15 +75,8 @@ public class SpaceFill extends CustomEnchantment<PlayerInteractEvent>{
     }
 
     private void runAreaFill(int level, Player player, Block clickedBlock) {
-        int neededBlocks = switch (level) {
-            case 1 -> 18;
-            case 2 -> 27;
-            case 3 -> 50;
-            case 4 -> 75;
-            default -> 0;
-        };
         var airBlocks = getAirBlocks(clickedBlock, player.getFacing(), level > 2 ? 5 : 3);
-        var availableItems = getAvailableItems(player.getInventory(), fillBlocks, neededBlocks);
+        var availableItems = getAvailableItems(player.getInventory(), fillBlocks, airBlocks.size());
         if (Objects.isNull(availableItems)) {
             ResourceBundle l18 = ResourceBundle.getBundle("translations.tools", player.locale());
             player.sendMessage(l18.getString("areaEnchNotEnoughItems"));

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: TesserTools
-version: '1.8.0'
+version: '1.8.1'
 main: de.bydora.tesserTools.TesserTools
 api-version: '1.21'
 author: FGBxRamel


### PR DESCRIPTION
This PR changes how the needed amount of blocks is calculated when using Space- or Area Fill enchantments. It now uses the actually needed amount, not a static value per level.